### PR TITLE
Android: correct target-dir, as package is com.ung.galleryrefresh

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
       </feature>
     </config-file>
     <config-file parent="/*" target="AndroidManifest.xml" />
-    <source-file src="src/android/GalleryRefresh.java" target-dir="src/com/ung/galleryrefresh/GalleryRefresh" />
+    <source-file src="src/android/GalleryRefresh.java" target-dir="src/com/ung/galleryrefresh" />
   </platform>
 
   <platform name="ios">


### PR DESCRIPTION
The class loading seems to work fine, but in Android Studio an error is given about the parent directory being `com/ung/galleryrefresh/GalleryRefresh` and not matching with the package, expected to be `com/ung/galleryrefresh` instead.