### PR TITLE
iOS: add not blank default usage description messages

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,12 +36,12 @@
     <header-file src="src/ios/GalleryRefresh.h" />
     <source-file src="src/ios/GalleryRefresh.m" compiler-flags="-fno-objc-arc"/>
 
-    <preference name="CAMERA_USAGE_DESCRIPTION" default=" " />
+    <preference name="CAMERA_USAGE_DESCRIPTION" default="Use the camera" />
     <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
         <string>$CAMERA_USAGE_DESCRIPTION</string>
     </config-file>
 
-    <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default=" " />
+    <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default="Use the photo library" />
     <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
         <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
     </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,17 +34,16 @@
     </config-file>
 
     <header-file src="src/ios/GalleryRefresh.h" />
-    <source-file src="src/ios/GalleryRefresh.m" compiler-flags="-fno-objc-arc"/>
+    <source-file src="src/ios/GalleryRefresh.m" compiler-flags="-fno-objc-arc" />
 
     <preference name="CAMERA_USAGE_DESCRIPTION" default="Use the camera" />
     <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
-        <string>$CAMERA_USAGE_DESCRIPTION</string>
+      <string>$CAMERA_USAGE_DESCRIPTION</string>
     </config-file>
 
     <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default="Use the photo library" />
     <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
-        <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
+      <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
     </config-file>
-
   </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
         <param name="android-package" value="com.ung.galleryrefresh.GalleryRefresh" />
       </feature>
     </config-file>
-    <config-file parent="/*" target="AndroidManifest.xml" />
+
     <source-file src="src/android/GalleryRefresh.java" target-dir="src/com/ung/galleryrefresh/GalleryRefresh" />
   </platform>
 


### PR DESCRIPTION
Prefer minimal non empty nor blank default values for the usage description messages.

---
\+ remove `<config-file>` without content